### PR TITLE
gencert sub command for S/MIME using Bulk endpoint

### DIFF
--- a/cmd/genCertSmime.go
+++ b/cmd/genCertSmime.go
@@ -125,8 +125,7 @@ var genCertSmimeCmd = &cobra.Command{
 		// build fake bulk request with sinlge user
 		// it looks like the API still does not fully support requesting a single SMIME certificate
 		// the request endpoint exists but no review/validation endpoint - atleast missing in API description
-		var smimeBulk models.SmimeBulkRequest
-		smimeBulk = models.SmimeBulkRequest{
+		var smimeBulk = models.SmimeBulkRequest{
 			FriendlyName:   genCertSmimeConfig.FriendlyName,
 			Email:          genCertSmimeConfig.Email,
 			Email2:         "",


### PR DESCRIPTION
I did an implementation of a sub command for the "gen-cert" command.
It can be used to enroll S/MIME certificates using the CSV bulk endpoint.
Sadly I am not aware of any proper API description so this is done with the few information I was able to found.
The implementation is tested successfully and already in use.
Each request will only enroll a single certificate, the Bulk endpoint is only used because it is already working for automation. 

Further improvements needs to be done as soon as the API provides a proper endpoint to request S/MIME certificates.