### PR TITLE
fix: Ensure environment support for API funcs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -109,39 +109,28 @@ func NewClient(user, password, totpSeed string, options ...Option) (*Client, err
 	return &c, nil
 }
 
-func WithProductionEnvironment() Option {
-	return func(c *Client) {
-		c.baseURL = BaseURLProduction
-	}
-}
-
-func WithStagingEnvironment() Option {
-	return func(c *Client) {
-		c.baseURL = BaseURLStaging
-	}
-}
-
-func WithDevelEnvironment() Option {
-	return func(c *Client) {
-		c.baseURL = BaseURLDevel
-	}
-}
-
 func WithDebug(debug bool) Option {
 	return func(c *Client) {
 		c.debug = debug
 	}
 }
 
-// WithEnvironment returns the appropriate environment option based on the environment string
-func WithEnvironment(env string) Option {
+// BaseURL resolves the base URL string for the given environment name.
+func BaseURL(env string) string {
 	switch env {
 	case "staging":
-		return WithStagingEnvironment()
+		return BaseURLStaging
 	case "devel":
-		return WithDevelEnvironment()
+		return BaseURLDevel
 	default:
-		return WithProductionEnvironment()
+		return BaseURLProduction
+	}
+}
+
+// WithEnvironment returns the appropriate environment option based on the environment string
+func WithEnvironment(env string) Option {
+	return func(c *Client) {
+		c.baseURL = BaseURL(env)
 	}
 }
 

--- a/cmd/genCertSmime.go
+++ b/cmd/genCertSmime.go
@@ -132,7 +132,7 @@ var genCertSmimeCmd = &cobra.Command{
 			slog.Info("Using API-key mode for S/MIME bulk issuance")
 			if strings.TrimSpace(resolvedOrganizationID) == "" {
 				slog.Info("No organization id provided; attempting autodiscovery via /cm/v1/admin/enterprises")
-				enterprises, raw, err := client.ListCMv1Enterprises(client.BaseURLProduction, resolvedAPIKey, debug)
+				enterprises, raw, err := client.ListCMv1Enterprises(client.BaseURL(environment), resolvedAPIKey, debug)
 				if err != nil {
 					if len(raw) > 0 {
 						fmt.Fprintln(os.Stderr, string(raw))
@@ -181,7 +181,7 @@ var genCertSmimeCmd = &cobra.Command{
 				slog.Debug("CSR logged:", slog.Any("csr", smimeBulk.CSR))
 			}
 
-			zipBytes, err := client.CreateCMv1SmimeBulkZip(client.BaseURLProduction, resolvedAPIKey, resolvedOrganizationID, smimeBulk, debug)
+			zipBytes, err := client.CreateCMv1SmimeBulkZip(client.BaseURL(environment), resolvedAPIKey, resolvedOrganizationID, smimeBulk, debug)
 			if err != nil {
 				if e, ok := err.(*client.UnexpectedResponseCodeError); ok {
 					fmt.Fprintln(os.Stderr, string(e.Body))

--- a/cmd/orgIDs.go
+++ b/cmd/orgIDs.go
@@ -21,7 +21,7 @@ var orgIDsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		enterprises, raw, err := client.ListCMv1Enterprises(client.BaseURLProduction, apiKey, debug)
+		enterprises, raw, err := client.ListCMv1Enterprises(client.BaseURL(environment), apiKey, debug)
 		if err != nil {
 			if len(raw) > 0 {
 				fmt.Fprintln(os.Stderr, string(raw))


### PR DESCRIPTION
Hello,

This PR addresses the fact that the API functionality was always using/targeting the production endpoint. 

I've simplified the existing environment functionality around the `BaseURL` function which is now also used by `WithEnvironment` so both the `WithEnvironment` client option and standalone functions that accept a raw base URL, which the API code is using, are supported.

The API functionality currently works when you supply your own CSR:
```
./harica -e staging --api-key mysecretkey gen-cert smime \
  --email foo.bar@foo.bar \
  --given-name "Foo" \
  --sur-name "Bar" \
  --csr "$(cat test.csr)"
2026/03/03 16:20:42 INFO No configuration file found
2026/03/03 16:20:42 INFO Using API-key mode for S/MIME bulk issuance
2026/03/03 16:20:42 INFO No organization id provided; attempting autodiscovery via /cm/v1/admin/enterprises
2026/03/03 16:20:55 INFO Autodiscovered organization id organization_id=my-redacted-org-id
-----BEGIN CERTIFICATE-----
```

But when no CSR is supplied, the code breaks in the same way on the empty pickupPassword as we have seen before. Asides from that, another format will be returned than currently expected (.p12 vs .p7) which results in only the zip output method working.

I'll handle these things in a new PR if that's fine.

Kind regards,

Bob