### PR TITLE
feat: generalize S/MIME output and unify API-key and session flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ bin/
 
 # bulk response artifacts
 *.zip
+*.p12
+*.p7b
 
 # Config files for local development
 dns_configs

--- a/client/apikey.go
+++ b/client/apikey.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hm-edu/harica/models"
 	"go.mozilla.org/pkcs7"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 func scanDERCertificates(data []byte) []*x509.Certificate {
@@ -220,19 +221,60 @@ func CreateCMv1SmimeBulkZip(baseURL, apiKey, organizationID string, request mode
 	return body, nil
 }
 
+// ExtractPKCSFromZip locates the first PKCS#12 or PKCS#7 file in the zip and returns
+// its raw bytes along with the detected file extension (".p12" or ".p7b").
+func ExtractPKCSFromZip(zipBytes []byte) ([]byte, string, error) {
+	if len(zipBytes) == 0 {
+		return nil, "", errors.New("zip is empty")
+	}
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		return nil, "", err
+	}
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		name := strings.ToLower(f.Name)
+		var ext string
+		switch {
+		case strings.HasSuffix(name, ".p12") || strings.HasSuffix(name, ".pfx"):
+			ext = ".p12"
+		case strings.HasSuffix(name, ".p7b") || strings.HasSuffix(name, ".p7c"):
+			ext = ".p7b"
+		default:
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, "", err
+		}
+		data, readErr := io.ReadAll(io.LimitReader(rc, 25<<20))
+		_ = rc.Close()
+		if readErr != nil {
+			return nil, "", readErr
+		}
+		return data, ext, nil
+	}
+	return nil, "", errors.New("no PKCS#12 or PKCS#7 file found in zip")
+}
+
 // ExtractFirstCertificatePEMFromZip tries to locate the first leaf certificate in the ZIP
 // response and returns it as PEM.
 //
 // The HARICA bulk S/MIME endpoint returns a ZIP on success. For single-user requests
 // we use this helper to keep stdout output compatible with legacy flows.
-func ExtractFirstCertificatePEMFromZip(zipBytes []byte) (string, error) {
+//
+// A private key PEM is also returned if a PKCS#12 file is
+// found and successfully decrypted with the pickup password.
+func ExtractFirstCertificatePEMFromZip(zipBytes []byte, pickupPassword string) (string, string, error) {
 	if len(zipBytes) == 0 {
-		return "", errors.New("zip is empty")
+		return "", "", errors.New("zip is empty")
 	}
 
 	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	var lastX509Err error
@@ -257,12 +299,29 @@ func ExtractFirstCertificatePEMFromZip(zipBytes []byte) (string, error) {
 			if !strings.HasSuffix(text, "\n") {
 				text += "\n"
 			}
-			return text, nil
+			return text, "", nil
+		}
+
+		// HARICA bulk S/MIME ZIPs may contain a PKCS#12 (.p12) file when no CSR was
+		// supplied. We decrypt it with the pickup password and return the leaf cert
+		// and private key.
+		name := strings.ToLower(f.Name)
+		if strings.HasSuffix(name, ".p12") || strings.HasSuffix(name, ".pfx") {
+			privateKey, cert, _, err := pkcs12.DecodeChain(data, pickupPassword)
+			if err != nil {
+				return "", "", fmt.Errorf("failed to decode pkcs12 file %q (wrong pickup password?): %w", f.Name, err)
+			}
+			certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
+			keyBlock, err := x509.MarshalPKCS8PrivateKey(privateKey)
+			if err != nil {
+				return "", "", fmt.Errorf("failed to marshal private key from pkcs12 file %q: %w", f.Name, err)
+			}
+			return string(pem.EncodeToMemory(certBlock)), string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBlock})), nil
 		}
 
 		if cert, err := x509.ParseCertificate(data); err == nil {
 			block := &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
-			return string(pem.EncodeToMemory(block)), nil
+			return string(pem.EncodeToMemory(block)), "", nil
 		} else {
 			lastX509Err = err
 		}
@@ -283,7 +342,7 @@ func ExtractFirstCertificatePEMFromZip(zipBytes []byte) (string, error) {
 			}
 			if chosen != nil {
 				block := &pem.Block{Type: "CERTIFICATE", Bytes: chosen.Raw}
-				return string(pem.EncodeToMemory(block)), nil
+				return string(pem.EncodeToMemory(block)), "", nil
 			}
 		} else {
 			lastPKCS7Err = err
@@ -299,17 +358,17 @@ func ExtractFirstCertificatePEMFromZip(zipBytes []byte) (string, error) {
 				}
 				if chosen != nil {
 					block := &pem.Block{Type: "CERTIFICATE", Bytes: chosen.Raw}
-					return string(pem.EncodeToMemory(block)), nil
+					return string(pem.EncodeToMemory(block)), "", nil
 				}
 			}
 		}
 	}
 
 	if lastPKCS7Err != nil {
-		return "", fmt.Errorf("no certificate found in zip (last pkcs7 parse error: %w)", lastPKCS7Err)
+		return "", "", fmt.Errorf("no certificate found in zip (last pkcs7 parse error: %w)", lastPKCS7Err)
 	}
 	if lastX509Err != nil {
-		return "", fmt.Errorf("no certificate found in zip (last x509 parse error: %w)", lastX509Err)
+		return "", "", fmt.Errorf("no certificate found in zip (last x509 parse error: %w)", lastX509Err)
 	}
-	return "", errors.New("no certificate found in zip")
+	return "", "", errors.New("no certificate found in zip")
 }

--- a/client/client.go
+++ b/client/client.go
@@ -752,7 +752,8 @@ func (c *Client) RequestSmimeBulkCertificates(groupId string, request models.Smi
 		return nil, err
 	}
 
-	return &models.SmimeBulkResponse{TransactionID: cert.ID, Certificate: cert.Certificate, Pkcs7: cert.Pkcs7}, nil
+	pkcs12, _ := cert.Pkcs12.(string)
+	return &models.SmimeBulkResponse{TransactionID: cert.ID, Certificate: cert.Certificate, Pkcs7: cert.Pkcs7, Pkcs12: pkcs12}, nil
 }
 
 func (c *Client) GetSmimeBulkCertificateEntries() (*[]models.BulkCertificateListEntry, error) {

--- a/cmd/genCertSmime.go
+++ b/cmd/genCertSmime.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"archive/zip"
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -33,8 +35,8 @@ type GenCertSmimeConfig struct {
 var (
 	genCertSmimeConfig GenCertSmimeConfig
 	configPathSmime    string
-	smimeOutputFormat  string
-	smimeZipOutPath    string
+	smimeOutputType    string
+	smimeOutputPath    string
 	keyMappingSmime    = map[string]string{
 		"csr":                 "csr",
 		"cert-type":           "cert_type",
@@ -56,6 +58,136 @@ func generateRandomPassword(length int) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
+}
+
+// resolvePickupPassword normalises the pickup password field on genCertSmimeConfig:
+// - clears it when a CSR is provided (the server does not use it and may reject a non-empty value)
+// - generates a random 16-char password when none was supplied
+// - keeps the provided value otherwise
+func resolvePickupPassword(cfg *GenCertSmimeConfig) error {
+	if strings.TrimSpace(cfg.Csr) != "" {
+		if cfg.PickupPassword != "" {
+			slog.Info("Pickup password is ignored when a CSR is provided")
+		}
+		cfg.PickupPassword = ""
+		return nil
+	}
+	if cfg.PickupPassword == "" {
+		pw, err := generateRandomPassword(16)
+		if err != nil {
+			return err
+		}
+		cfg.PickupPassword = pw
+		slog.Info("Generated random pickup password", slog.String("password", cfg.PickupPassword))
+		return nil
+	}
+	slog.Info("Using provided pickup password", slog.String("password", cfg.PickupPassword))
+	return nil
+}
+
+// resolvePKCSData returns the raw PKCS bytes and file extension to use for pkcs/zip
+// output. It tries, in order: raw pkcsBytes from the API-key zip, base64-encoded
+// pkcs12B64 from the session path, and finally pkcs7PEM from the session path.
+func resolvePKCSData(pkcsBytes []byte, pkcsExt, pkcs12B64, pkcs7PEM string) ([]byte, string) {
+	if len(pkcsBytes) > 0 {
+		return pkcsBytes, pkcsExt
+	}
+	if pkcs12B64 != "" {
+		data, err := base64.StdEncoding.DecodeString(pkcs12B64)
+		if err != nil {
+			slog.Error("failed to decode pkcs12 data", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return data, ".p12"
+	}
+	if pkcs7PEM != "" {
+		return []byte(pkcs7PEM), ".p7b"
+	}
+	slog.Error("no PKCS data available for output")
+	os.Exit(1)
+	return nil, ""
+}
+
+// handleSmimeOutput runs the output switch shared by both the API-key and session
+// paths. zipBytes and pkcsBytes/pkcsExt are only populated by the API-key path;
+// certPEM, keyPEM, pkcs7PEM, and pkcs12B64 are used by both.
+//
+//   - pem:  prints certPEM (and keyPEM when present) to stdout
+//   - pkcs: writes the resolved PKCS file to --output-path
+//   - zip:  writes raw zipBytes to --output-path (API-key path), or builds a zip
+//     from the resolved PKCS data (session path)
+func handleSmimeOutput(certPEM, keyPEM, pkcs7PEM, pkcs12B64 string, pkcsBytes []byte, pkcsExt string, zipBytes []byte) {
+	switch strings.ToLower(strings.TrimSpace(smimeOutputType)) {
+	case "pem":
+		fmt.Print(certPEM)
+		if keyPEM != "" {
+			fmt.Print(keyPEM)
+		}
+	case "pkcs":
+		data, ext := resolvePKCSData(pkcsBytes, pkcsExt, pkcs12B64, pkcs7PEM)
+		outPath := strings.TrimSpace(smimeOutputPath)
+		if outPath == "" {
+			outPath = filepath.Join(".", "smime"+ext)
+		}
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			slog.Error("failed to write PKCS file", slog.String("path", outPath), slog.Any("error", err))
+			os.Exit(1)
+		}
+		slog.Info("Wrote PKCS file", slog.String("path", outPath))
+		fmt.Println(outPath)
+	case "zip":
+		outPath := strings.TrimSpace(smimeOutputPath)
+		if outPath == "" {
+			outPath = filepath.Join(".", "smime.zip")
+		}
+		if len(zipBytes) > 0 {
+			if err := os.WriteFile(outPath, zipBytes, 0o644); err != nil {
+				slog.Error("failed to write zip", slog.String("path", outPath), slog.Any("error", err))
+				os.Exit(1)
+			}
+		} else {
+			data, ext := resolvePKCSData(pkcsBytes, pkcsExt, pkcs12B64, pkcs7PEM)
+			buf := new(bytes.Buffer)
+			zw := zip.NewWriter(buf)
+			f, err := zw.Create("smime" + ext)
+			if err != nil {
+				slog.Error("failed to create zip entry", slog.Any("error", err))
+				os.Exit(1)
+			}
+			if _, err := f.Write(data); err != nil {
+				slog.Error("failed to write zip entry", slog.Any("error", err))
+				os.Exit(1)
+			}
+			if err := zw.Close(); err != nil {
+				slog.Error("failed to finalise zip", slog.Any("error", err))
+				os.Exit(1)
+			}
+			if err := os.WriteFile(outPath, buf.Bytes(), 0o644); err != nil {
+				slog.Error("failed to write zip", slog.String("path", outPath), slog.Any("error", err))
+				os.Exit(1)
+			}
+		}
+		slog.Info("Wrote S/MIME ZIP", slog.String("path", outPath))
+		fmt.Println(outPath)
+	default:
+		slog.Error("invalid output type; use pem, pkcs, or zip", slog.String("output-type", smimeOutputType))
+		os.Exit(1)
+	}
+}
+
+// buildSmimeBulkRequest constructs a SmimeBulkRequest from the resolved config.
+func buildSmimeBulkRequest(cfg GenCertSmimeConfig) models.SmimeBulkRequest {
+	return models.SmimeBulkRequest{
+		FriendlyName:   cfg.FriendlyName,
+		Email:          cfg.Email,
+		Email2:         "",
+		Email3:         "",
+		GivenName:      cfg.GivenName,
+		Surname:        cfg.SurName,
+		PickupPassword: cfg.PickupPassword,
+		CertType:       cfg.CertType,
+		CSR:            cfg.Csr,
+	}
 }
 
 // genCertCmd represents the genCert command
@@ -166,20 +298,13 @@ var genCertSmimeCmd = &cobra.Command{
 
 			slog.Debug("Using organization id", slog.String("organization_id", resolvedOrganizationID))
 
-			var smimeBulk = models.SmimeBulkRequest{
-				FriendlyName:   genCertSmimeConfig.FriendlyName,
-				Email:          genCertSmimeConfig.Email,
-				Email2:         "",
-				Email3:         "",
-				GivenName:      genCertSmimeConfig.GivenName,
-				Surname:        genCertSmimeConfig.SurName,
-				PickupPassword: "",
-				CertType:       genCertSmimeConfig.CertType,
-				CSR:            genCertSmimeConfig.Csr,
+			if err := resolvePickupPassword(&genCertSmimeConfig); err != nil {
+				slog.Error("failed to resolve pickup password", slog.Any("error", err))
+				os.Exit(1)
 			}
-			if debug {
-				slog.Debug("CSR logged:", slog.Any("csr", smimeBulk.CSR))
-			}
+
+			smimeBulk := buildSmimeBulkRequest(genCertSmimeConfig)
+			slog.Debug("CSR logged:", slog.Any("csr", smimeBulk.CSR))
 
 			zipBytes, err := client.CreateCMv1SmimeBulkZip(client.BaseURL(environment), resolvedAPIKey, resolvedOrganizationID, smimeBulk, debug)
 			if err != nil {
@@ -195,35 +320,27 @@ var genCertSmimeCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			output := strings.ToLower(strings.TrimSpace(smimeOutputFormat))
-			if output == "" {
-				output = "pem"
-			}
-			switch output {
-			case "zip":
-				outPath := strings.TrimSpace(smimeZipOutPath)
-				if outPath == "" {
-					outPath = filepath.Join(".", "smime.zip")
-				}
-				if err := os.WriteFile(outPath, zipBytes, 0o644); err != nil {
-					slog.Error("failed to write zip", slog.String("path", outPath), slog.Any("error", err))
-					os.Exit(1)
-				}
-				slog.Info("Wrote S/MIME ZIP", slog.String("path", outPath))
-				fmt.Println(outPath)
-				return
+			var certPEM, keyPEM string
+			var pkcsBytes []byte
+			var pkcsExt string
+			switch strings.ToLower(strings.TrimSpace(smimeOutputType)) {
 			case "pem":
-				pemCert, err := client.ExtractFirstCertificatePEMFromZip(zipBytes)
+				var err error
+				certPEM, keyPEM, err = client.ExtractFirstCertificatePEMFromZip(zipBytes, genCertSmimeConfig.PickupPassword)
 				if err != nil {
 					slog.Error("failed to extract certificate from zip", slog.Any("error", err))
 					os.Exit(1)
 				}
-				fmt.Print(pemCert)
-				return
-			default:
-				slog.Error("invalid output format; use pem or zip", slog.String("output", smimeOutputFormat))
-				os.Exit(1)
+			case "pkcs":
+				var err error
+				pkcsBytes, pkcsExt, err = client.ExtractPKCSFromZip(zipBytes)
+				if err != nil {
+					slog.Error("failed to extract PKCS file from zip", slog.Any("error", err))
+					os.Exit(1)
+				}
 			}
+			handleSmimeOutput(certPEM, keyPEM, "", "", pkcsBytes, pkcsExt, zipBytes)
+			return
 		}
 
 		if strings.TrimSpace(genCertSmimeConfig.RequesterEmail) == "" || strings.TrimSpace(genCertSmimeConfig.RequesterPassword) == "" || strings.TrimSpace(genCertSmimeConfig.RequesterTOTPSeed) == "" {
@@ -254,46 +371,22 @@ var genCertSmimeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Handle pickup password: when a CSR is provided, the pickup password must be empty to avoid issues
-		if strings.TrimSpace(genCertSmimeConfig.Csr) != "" {
-			if genCertSmimeConfig.PickupPassword != "" {
-				slog.Info("Pickup password is ignored when a CSR is provided")
-			}
-			genCertSmimeConfig.PickupPassword = ""
-		} else if genCertSmimeConfig.PickupPassword == "" {
-			var err error
-			genCertSmimeConfig.PickupPassword, err = generateRandomPassword(16)
-			if err != nil {
-				slog.Error("failed to generate random pickup password", slog.Any("error", err))
-				os.Exit(1)
-			}
-			slog.Info("Generated random pickup password", slog.String("password", genCertSmimeConfig.PickupPassword))
-		} else {
-			slog.Info("Using provided pickup password", slog.String("password", genCertSmimeConfig.PickupPassword))
+		if err := resolvePickupPassword(&genCertSmimeConfig); err != nil {
+			slog.Error("failed to resolve pickup password", slog.Any("error", err))
+			os.Exit(1)
 		}
 
 		// build fake bulk request with single user
 		// it looks like the API still does not fully support requesting a single SMIME certificate
 		// the request endpoint exists but no review/validation endpoint - atleast missing in API description
-		var smimeBulk = models.SmimeBulkRequest{
-			FriendlyName:   genCertSmimeConfig.FriendlyName,
-			Email:          genCertSmimeConfig.Email,
-			Email2:         "",
-			Email3:         "",
-			GivenName:      genCertSmimeConfig.GivenName,
-			Surname:        genCertSmimeConfig.SurName,
-			PickupPassword: genCertSmimeConfig.PickupPassword,
-			CertType:       genCertSmimeConfig.CertType,
-			CSR:            genCertSmimeConfig.Csr,
-		}
+		smimeBulk := buildSmimeBulkRequest(genCertSmimeConfig)
 		slog.Debug("CSR logged:", slog.Any("csr", smimeBulk.CSR))
 		transaction, err := requester.RequestSmimeBulkCertificates(orgs[0].ID, smimeBulk)
 		if err != nil {
 			slog.Error("failed to request certificate", slog.Any("error", err))
 			os.Exit(1)
 		}
-		// regarding the code RequestSmimeBulkCertificates returns: TransactionID: cert.ID, Certificate: cert.Certificate, Pkcs7: cert.Pkcs7
-		fmt.Print(transaction.Certificate)
+		handleSmimeOutput(transaction.Certificate, "", transaction.Pkcs7, transaction.Pkcs12, nil, "", nil)
 	},
 }
 
@@ -311,6 +404,6 @@ func init() {
 	genCertSmimeCmd.Flags().String("given-name", "", "Givenname of the certificate requestor")
 	genCertSmimeCmd.Flags().String("sur-name", "", "Surname of the certificate requestor")
 	genCertSmimeCmd.Flags().String("pickup-password", "", "Password for certificate pickup (if not provided, a random password will be generated)")
-	genCertSmimeCmd.Flags().StringVar(&smimeOutputFormat, "output", "pem", "Output format in API-key mode: pem (default) or zip")
-	genCertSmimeCmd.Flags().StringVar(&smimeZipOutPath, "zip-out", "", "Output ZIP path when --output=zip (default: ./smime.zip)")
+	genCertSmimeCmd.Flags().StringVar(&smimeOutputType, "output-type", "pem", "Output type: pem (default), pkcs (.p12/.p7b), or zip")
+	genCertSmimeCmd.Flags().StringVar(&smimeOutputPath, "output-path", "", "Output file path for pkcs and zip output types (default: ./smime.<ext>)")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.mozilla.org/pkcs7 v0.9.0
 	golang.org/x/net v0.51.0
 	gopkg.in/yaml.v3 v3.0.1
+	software.sslmate.com/src/go-pkcs12 v0.7.0
 )
 
 require (
@@ -30,6 +31,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
@@ -79,8 +81,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -120,3 +120,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.7.0 h1:Db8W44cB54TWD7stUFFSWxdfpdn6fZVcDl0w3R4RVM0=
+software.sslmate.com/src/go-pkcs12 v0.7.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/models/certificate.go
+++ b/models/certificate.go
@@ -107,6 +107,7 @@ type SmimeBulkResponse struct {
 	TransactionID string `json:"id"`
 	Certificate   string `json:"certificate"`
 	Pkcs7         string `json:"pkcs7"`
+	Pkcs12        string `json:"pkcs12"`
 }
 
 type BulkCertificateListEntry struct {


### PR DESCRIPTION
Hello,

I took some time to work on the SMIME functionality again.

As mentioned in the commit itself, the following points has been addressed:

- Fix missing pickup password logic in API-key path
- Add PKCS#12 support in zip extraction
- Add pkcs and zip output types alongside existing pem, supported by both API-key and session paths
- Extract resolvePickupPassword, resolvePKCSData ,handleSmimeOutput and buildSmimeBulkRequest to helper functions to eliminate duplicate code
- Print private key in PEM output when no CSR is supplied
- Reworked `--output` and `--zip-out` to `--output-type` and `--output-path` supported by both API-key and session flows, with and without CSR supplied to unify all scenario's.

Now the same can be achieved with both API-key flow or session-based flow:
- Issuing a certificate with or without CSR (Resulting in p7b vs p12 or cert-pem vs cert+privkey-pem)
- Issuing a certificate with or without pickup-password (Resulting in generating one, supplying one or being discarded(CSR))
- Issuing a certificate with or without output-type and output-path flags

Thank you in advance for your time looking at this.

Kind regards,

Bob